### PR TITLE
Add PyTorch Lightning CNN training project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# CNN Classification with PyTorch Lightning
+
+This project trains a simple convolutional neural network on images stored in the `Images` folder. Labels are provided in `Label.csv`.
+
+## Requirements
+
+- Python 3.8+
+- torch
+- torchvision
+- pytorch-lightning
+- torchmetrics
+- pandas
+- scikit-learn
+- pillow
+
+Install dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Training
+
+Run the training script which uses batch size of 64 and trains for 30 epochs:
+
+```bash
+python train.py
+```
+
+The script logs Accuracy and F1 score on the validation set.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+torch
+torchvision
+pytorch-lightning
+torchmetrics
+pandas
+scikit-learn
+pillow

--- a/src/datamodule.py
+++ b/src/datamodule.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+from sklearn.model_selection import train_test_split
+import pandas as pd
+from torch.utils.data import DataLoader
+import torchvision.transforms as T
+import pytorch_lightning as pl
+
+from .dataset import ImageDataset
+
+class ImageDataModule(pl.LightningDataModule):
+    def __init__(self, csv_file, img_dir, batch_size=64):
+        super().__init__()
+        self.csv_file = csv_file
+        self.img_dir = Path(img_dir)
+        self.batch_size = batch_size
+        self.transform = T.Compose([
+            T.Resize((64, 64)),
+            T.ToTensor(),
+        ])
+
+    def prepare_data(self):
+        pass
+
+    def setup(self, stage=None):
+        df = pd.read_csv(self.csv_file)
+        labels = sorted(df['Label'].unique())
+        self.label2idx = {l: i for i, l in enumerate(labels)}
+        df['LabelIdx'] = df['Label'].map(self.label2idx)
+        train_df, val_df = train_test_split(df, test_size=0.2, random_state=42, stratify=df['LabelIdx'])
+        self.train_ds = ImageDataset(train_df, self.img_dir, self.transform)
+        self.val_ds = ImageDataset(val_df, self.img_dir, self.transform)
+        self.num_classes = len(labels)
+
+    def train_dataloader(self):
+        return DataLoader(self.train_ds, batch_size=self.batch_size, shuffle=True)
+
+    def val_dataloader(self):
+        return DataLoader(self.val_ds, batch_size=self.batch_size)

--- a/src/dataset.py
+++ b/src/dataset.py
@@ -1,0 +1,22 @@
+import pandas as pd
+from pathlib import Path
+from PIL import Image
+from torch.utils.data import Dataset
+
+class ImageDataset(Dataset):
+    def __init__(self, dataframe, img_dir, transform=None):
+        self.df = dataframe.reset_index(drop=True)
+        self.img_dir = Path(img_dir)
+        self.transform = transform
+
+    def __len__(self):
+        return len(self.df)
+
+    def __getitem__(self, idx):
+        row = self.df.iloc[idx]
+        img_path = self.img_dir / row['ImageName']
+        image = Image.open(img_path).convert('RGB')
+        label = row['LabelIdx']
+        if self.transform:
+            image = self.transform(image)
+        return image, label

--- a/src/model.py
+++ b/src/model.py
@@ -1,0 +1,47 @@
+import torch
+from torch import nn
+import pytorch_lightning as pl
+import torchmetrics
+
+class LitCNN(pl.LightningModule):
+    def __init__(self, num_classes, lr=1e-3):
+        super().__init__()
+        self.save_hyperparameters()
+        self.model = nn.Sequential(
+            nn.Conv2d(3, 32, kernel_size=3, padding=1),
+            nn.ReLU(),
+            nn.MaxPool2d(2),
+            nn.Conv2d(32, 64, kernel_size=3, padding=1),
+            nn.ReLU(),
+            nn.MaxPool2d(2),
+            nn.Flatten(),
+            nn.Linear(64 * 16 * 16, 128),
+            nn.ReLU(),
+            nn.Linear(128, num_classes)
+        )
+        self.criterion = nn.CrossEntropyLoss()
+        self.acc = torchmetrics.classification.Accuracy(task="multiclass", num_classes=num_classes)
+        self.f1 = torchmetrics.classification.F1Score(task="multiclass", num_classes=num_classes)
+
+    def forward(self, x):
+        return self.model(x)
+
+    def configure_optimizers(self):
+        return torch.optim.Adam(self.parameters(), lr=self.hparams.lr)
+
+    def _step(self, batch, stage):
+        x, y = batch
+        logits = self(x)
+        loss = self.criterion(logits, y)
+        acc = self.acc(logits, y)
+        f1 = self.f1(logits, y)
+        self.log(f"{stage}_loss", loss, prog_bar=True)
+        self.log(f"{stage}_acc", acc, prog_bar=True)
+        self.log(f"{stage}_f1", f1, prog_bar=True)
+        return loss
+
+    def training_step(self, batch, batch_idx):
+        return self._step(batch, 'train')
+
+    def validation_step(self, batch, batch_idx):
+        self._step(batch, 'val')

--- a/train.py
+++ b/train.py
@@ -1,0 +1,15 @@
+import pytorch_lightning as pl
+from pytorch_lightning import Trainer
+from src.datamodule import ImageDataModule
+from src.model import LitCNN
+
+
+def main():
+    data = ImageDataModule(csv_file='Label.csv', img_dir='Images', batch_size=64)
+    data.setup()
+    model = LitCNN(num_classes=data.num_classes)
+    trainer = Trainer(max_epochs=30)
+    trainer.fit(model, datamodule=data)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add PyTorch Lightning CNN training script for images
- include datamodule, dataset, and model definitions
- add requirements list and usage instructions

## Testing
- `python train.py` *(fails: ModuleNotFoundError: No module named 'pytorch_lightning')*

------
https://chatgpt.com/codex/tasks/task_e_683fe83f3070832e8701c726746cf69f